### PR TITLE
Add basic In Video Quiz functionality

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,8 @@ class Tox(TestCommand):
 setup(
     name='invideoquiz-xblock',
     version='0.1',
-    description='invideoquiz XBlock',   # TODO: write a better description.
-    license='UNKNOWN',          # TODO: choose a license: 'AGPL v3' and 'Apache 2.0' are popular.
+    description='Helper XBlock to locate CAPA problems within videos.',
+    license='AGPL v3',
     packages=[
         'invideoquiz',
     ],


### PR DESCRIPTION
- Leverages default video and problem components to take advantage of grading and theming
- Basic "in-video" learner view where components are displayed inside of video at the set time
- Instructor view where problems are displayed as normal problems with a message about when they appear in the video so instructors can still use all the problem data features
- Simple Studio view in which the video and problem component IDs can be set, as well as the timemap

@stv
