### PR TITLE
Fix in-video quiz questions not appearing properly over video

### DIFF
--- a/invideoquiz/public/js/src/invideoquiz.js
+++ b/invideoquiz/public/js/src/invideoquiz.js
@@ -87,6 +87,9 @@ function InVideoQuizXBlock(runtime, element) {
                 if (isProblemToDisplay) {
                   problemToDisplay = $('.xblock-student_view', this)
                   videoState.videoPlayer.pause();
+                  var videoPosition = $('.tc-wrapper', video).position().top;
+                  var videoHeight = $('.tc-wrapper', video).css('height');
+                  problemToDisplay.css({top: videoPosition, height: videoHeight});
                   problemToDisplay.show();
                   canDisplayProblem = false;
                 }


### PR DESCRIPTION
If a video isn't the first component in the unit, the in-video-quiz
questions appear incorrectly positioned on the page. This repositions
the questions to properly cover the video while it's paused.