### PR TITLE
Fix in-video quiz question issues with display, sizing, and alignment

### DIFF
--- a/invideoquiz/public/js/src/invideoquiz.js
+++ b/invideoquiz/public/js/src/invideoquiz.js
@@ -96,6 +96,7 @@ function InVideoQuizXBlock(runtime, element) {
                   videoState.videoPlayer.pause();
                   resizeInVideoProblem(problemToDisplay, video);
                   problemToDisplay.show();
+                  problemToDisplay.css({display: 'block'});
                   canDisplayProblem = false;
                 }
               });

--- a/invideoquiz/public/js/src/invideoquiz.js
+++ b/invideoquiz/public/js/src/invideoquiz.js
@@ -61,6 +61,13 @@ function InVideoQuizXBlock(runtime, element) {
             }
         });
     }
+    
+    function resizeInVideoProblem(currentProblem, currentVideo) {
+        var videoPosition = $('.tc-wrapper', currentVideo).position().top;
+        var videoHeight = $('.tc-wrapper', currentVideo).css('height');
+        var videoWidth = $('.tc-wrapper', currentVideo).css('width');
+        currentProblem.css({top: videoPosition, height: videoHeight, width: videoWidth});
+    }
 
     // Bind In Video Quiz display to video time, as well as play and pause buttons
     function bindVideoEvents() {
@@ -87,6 +94,7 @@ function InVideoQuizXBlock(runtime, element) {
                 if (isProblemToDisplay) {
                   problemToDisplay = $('.xblock-student_view', this)
                   videoState.videoPlayer.pause();
+                  resizeInVideoProblem(problemToDisplay, video);
                   problemToDisplay.show();
                   canDisplayProblem = false;
                 }

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ class Tox(TestCommand):
 
 setup(
     name='invideoquiz-xblock',
-    version='0.1.4',
+    version='0.1.5',
     description='Helper XBlock to locate CAPA problems within videos.',
     license='AGPL v3',
     packages=[


### PR DESCRIPTION
This set of commits fixes issues with the question alignment when the video isn't the first component, question sizing/alignment when a video is resized (window resize or un-fullscreening) with a question open, and questions displaying inconsistently because of a css issue. 