### PR TITLE
Fix videostate being undefined if YouTube API loads slowly

### DIFF
--- a/invideoquiz/public/js/src/invideoquiz.js
+++ b/invideoquiz/public/js/src/invideoquiz.js
@@ -46,7 +46,6 @@ function InVideoQuizXBlock(runtime, element) {
         var componentIsVideo = component.data('id').indexOf(videoId) !== -1;
         if (componentIsVideo) {
             video = $('.video', component);
-            videoState = video.data('video-player-state');
         } else {
             $.each(problemTimesMap, function (time, componentId) {
                 if (component.data('id').indexOf(componentId) !== -1) {
@@ -103,6 +102,8 @@ function InVideoQuizXBlock(runtime, element) {
         var problemToDisplay;
 
         video.on('play', function () {
+          videoState = videoState || video.data('video-player-state');
+
           clearInterval(resizeIntervalObject);
 
           if (problemToDisplay) {
@@ -134,6 +135,7 @@ function InVideoQuizXBlock(runtime, element) {
         });
 
         video.on('pause', function () {
+          videoState = videoState || video.data('video-player-state');
           clearInterval(intervalObject);
           if (problemToDisplay) {
             resizeIntervalObject = setInterval(function () {


### PR DESCRIPTION
In some instances, when the youtube API had not yet loaded,
the assignment of the videoState variable would result in undefined;
this led to issues of the in-video-quiz questions not appearing properly.
We move the assignment to the 'play' video event, which only occurs
when the API has fully loaded

@caesar2164 @stvstnfrd 