### PR TITLE
Changed required version of django in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'invideoquiz',
     ],
     install_requires=[
-        'django >= 1.8, < 1.9',
+        'django >= 1.8',
         'django_nose',
         'mock',
         'coverage',


### PR DESCRIPTION
We have removed the upper limit of required Django (<1.9) version due to hawthorn release requiring Django version 1.11. The changes have been tested on the open EdX platform hawthorn release.