### PR TITLE
Add flag for showing the in-video-quiz xblock in read only mode

### DIFF
--- a/invideoquiz/invideoquiz.py
+++ b/invideoquiz/invideoquiz.py
@@ -30,6 +30,8 @@ class InVideoQuizXBlock(StudioEditableXBlockMixin, XBlock):
     Display CAPA problems within a video component at a specified time.
     """
 
+    show_in_read_only_mode = True
+
     display_name = String(
         display_name=_('Display Name'),
         default=_('In-Video Quiz XBlock'),


### PR DESCRIPTION
Made the in-video-quiz xblock visible for specified students.

Tested locally on studio and lms, through adding the xblock to a course
and toggling view between staff and specified student.

@stvstnfrd @caesar2164 