### PR TITLE
BOM-1576: Added python 3.8 in test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: false
 language: python
 cache: pip
 python:
-    - '3.5'
+    - 3.5
+    - 3.8
 before_install:
     - 'uname -a'
     - 'python --version'
@@ -18,10 +19,12 @@ branches:
     only:
       - 'master'
 env:
-    - TOXENV=py35-django111
-    - TOXENV=py35-django20
-    - TOXENV=py35-django21
-    - TOXENV=py35-django22
-    - TOXENV=coverage
-    - TOXENV=pep8
-    - TOXENV=pylint
+    - TOXENV=django22
+matrix:
+    include:
+        - python: 3.5
+          env: TOXENV=coverage
+        - python: 3.5
+          env: TOXENV=pep8
+        - python: 3.5
+          env: TOXENV=pylint

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: python
 cache: pip
 python:
-    - '2.7'
+    - '3.5'
 before_install:
     - 'uname -a'
     - 'python --version'
@@ -18,7 +18,10 @@ branches:
     only:
       - 'master'
 env:
-    - TOXENV=py27-dj18
-    - TOXENV=coveralls
+    - TOXENV=py35-django111
+    - TOXENV=py35-django20
+    - TOXENV=py35-django21
+    - TOXENV=py35-django22
+    - TOXENV=coverage
     - TOXENV=pep8
     - TOXENV=pylint

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'invideoquiz',
     ],
     install_requires=[
-        'django >= 1.8',
+        'django<3.0',
         'django_nose',
         'mock',
         'coverage',

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,17 @@
 
 [tox]
 downloadcache = {toxworkdir}/_download/
-envlist = py27-dj18,coverage,pep8,pylint
+envlist = {py35}-django{111,20,21,22},coverage,pep8,pylint
 
 [testenv]
-commands = {envpython} manage.py test
-
-[testenv:py27-dj18]
-deps =
+deps:
+    django111: Django>=1.11,<2.0
+    django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
+    django22: Django>=2.2,<2.3
     -rrequirements.txt
+commands =
+    python manage.py test
 
 [testenv:pep8]
 deps =
@@ -32,14 +35,3 @@ setenv =
 commands =
     {envpython} manage.py test
 
-[testenv:coveralls]
-deps =
-    -rrequirements.txt
-    coveralls
-setenv =
-    NOSE_COVER_TESTS=1
-    NOSE_WITH_COVERAGE=1
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
-commands =
-    {envbindir}/coverage run --source=invideoquiz manage.py test
-    {envbindir}/coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,12 @@
 
 [tox]
 downloadcache = {toxworkdir}/_download/
-envlist = {py35}-django{111,20,21,22},coverage,pep8,pylint
+envlist = {py35,38}-django{22,30},coverage,pep8,pylint
 
 [testenv]
 deps:
-    django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
     -rrequirements.txt
 commands =
     python manage.py test


### PR DESCRIPTION
- Added python3.8 travis worker
- Added Django 3.0 in tox file for testing
- Removed support for python < 3.5 and Django < 2.2

https://openedx.atlassian.net/browse/BOM-1576