### PR TITLE
feat: translate text button of 'Continue'

### DIFF
--- a/invideoquiz/invideoquiz.py
+++ b/invideoquiz/invideoquiz.py
@@ -85,6 +85,8 @@ class InVideoQuizXBlock(StudioEditableXBlockMixin, XBlock):
             context={
                 'video_id': self.video_id,
                 'user_mode': self.user_mode,
+                'continue': _('Continue')
+
             },
         )
         config = get_resource_string('js/src/config.js')

--- a/invideoquiz/public/html/invideoquiz.html
+++ b/invideoquiz/public/html/invideoquiz.html
@@ -1,1 +1,1 @@
-<div class="in-video-quiz-block" data-videoid="{video_id}" data-mode='{user_mode}'></div>
+<div class="in-video-quiz-block" data-continue-text="{continue}" data-videoid="{video_id}" data-mode='{user_mode}'></div>

--- a/invideoquiz/public/js/src/invideoquiz.js
+++ b/invideoquiz/public/js/src/invideoquiz.js
@@ -7,7 +7,9 @@ function InVideoQuizXBlock(runtime, element) {
     }
     var problemTimesMap = InVideoQuizXBlock.config[videoId];
     var studentMode = $('.in-video-quiz-block').data('mode') !== 'staff';
-    var extraVideoButton = '<button class="in-video-continue">Continue</button>';
+
+    // We get the translted text from invideoquiz.html because gettext('Continue') didn't work
+    var extraVideoButton = '<button class="in-video-continue">' + $('.in-video-quiz-block').data('continue-text')  +'</button>';
     var video;
     var videoState;
 


### PR DESCRIPTION
This change make it possible that the text button of `Continue` is translatable